### PR TITLE
Update to version 1.1.7

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
 		"en": "CalDAV (calendar) and CardDAV (contact) synchronization server",
 		"fr": "Serveur de synchronisation CalDAV et CardDAV"
 	},
-	"version": "1.1.6~ynh6",
+	"version": "1.1.7~ynh1",
 	"url": "http://radicale.org",
     "upstream": {
         "license": "GPL-3.0,AGPL-3.0",

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -230,7 +230,7 @@ then
 	ynh_secure_remove --file="/opt/yunohost/$app"
 	virtualenv /opt/yunohost/$app
 	version=$(ynh_app_setting_get $app version $version)
-	bash -c "source /opt/yunohost/radicale/bin/activate && pip install radicale==$version python-ldap"
+	/opt/yunohost/$app/bin/pip install radicale==$version python-ldap
 
 	# regex.py file is patched to fix the awful commit e807c3d35bea9cfcfcacac83b1b17d748ea15a39 that stop the reading of "rights" file after the first match.
 	mv "$final_path/regex.py" /opt/yunohost/$app/lib/python*/site-packages/radicale/rights/regex.py


### PR DESCRIPTION
## Problem

- *version 1.1.6 was released on 24 July 2017*

## Solution

- *Update the latest version 1.1.7*

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
